### PR TITLE
bugfix the select params in QueryBuilder should set the FilterBuilder

### DIFF
--- a/src/main/kotlin/io/supabase/postgrest/builder/PostgrestBuilder.kt
+++ b/src/main/kotlin/io/supabase/postgrest/builder/PostgrestBuilder.kt
@@ -30,7 +30,10 @@ open class PostgrestBuilder<T : Any> {
         this.body = builder.body
         this.jsonConverter = builder.jsonConverter
         this.schema = schema
-        this.searchParams = builder.searchParams
+
+        builder.getSearchParams().forEach {
+            (name, value) -> setSearchParam(name, value)
+        }
     }
 
     constructor(url: URI, httpClient: PostgrestHttpClient, jsonConverter: PostgrestJsonConverter, headers: Map<String, String>, schema: String?) {

--- a/src/main/kotlin/io/supabase/postgrest/builder/PostgrestBuilder.kt
+++ b/src/main/kotlin/io/supabase/postgrest/builder/PostgrestBuilder.kt
@@ -30,6 +30,7 @@ open class PostgrestBuilder<T : Any> {
         this.body = builder.body
         this.jsonConverter = builder.jsonConverter
         this.schema = schema
+        this.searchParams = builder.searchParams
     }
 
     constructor(url: URI, httpClient: PostgrestHttpClient, jsonConverter: PostgrestJsonConverter, headers: Map<String, String>, schema: String?) {

--- a/src/main/kotlin/io/supabase/postgrest/builder/PostgrestBuilder.kt
+++ b/src/main/kotlin/io/supabase/postgrest/builder/PostgrestBuilder.kt
@@ -31,7 +31,11 @@ open class PostgrestBuilder<T : Any> {
         this.jsonConverter = builder.jsonConverter
         this.schema = schema
 
-        builder.getSearchParams().forEach {
+        var params = builder.searchParams
+        if (params == null) {
+            params = mutableMapOf()
+        }
+        params.forEach {
             (name, value) -> setSearchParam(name, value)
         }
     }

--- a/src/main/kotlin/io/supabase/postgrest/builder/PostgrestBuilder.kt
+++ b/src/main/kotlin/io/supabase/postgrest/builder/PostgrestBuilder.kt
@@ -31,11 +31,7 @@ open class PostgrestBuilder<T : Any> {
         this.jsonConverter = builder.jsonConverter
         this.schema = schema
 
-        var params = builder.searchParams
-        if (params == null) {
-            params = mutableMapOf()
-        }
-        params.forEach {
+        builder.searchParams.forEach {
             (name, value) -> setSearchParam(name, value)
         }
     }

--- a/src/test/kotlin/io/supabase/postgrest/builder/PostgrestFilterBuilderTest.kt
+++ b/src/test/kotlin/io/supabase/postgrest/builder/PostgrestFilterBuilderTest.kt
@@ -5,11 +5,13 @@ import assertk.assertions.isEqualTo
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.net.URI
 import kotlin.reflect.KProperty1
 
 internal class PostgrestFilterBuilderTest {
 
-    private val postgrestBuilderMock = mockk<PostgrestBuilder<Any>>()
+    private val postgrestBuilderMock = PostgrestBuilder<Any>(URI(""), mockk(), mockk(), emptyMap(), null)
+
     private var filterBuilder: PostgrestFilterBuilder<Any>? = null
 
     @BeforeEach


### PR DESCRIPTION
```
builder = client.from("item_with_categories")
       .select("num_iid,genders", false, Count.EXACT);
        .eq("seller_id", 1);

builder.getSearchParams()

only have the `seller_id` eq.1.

```